### PR TITLE
Translate admin interface from Spanish to English

### DIFF
--- a/apps/web-admin/src/app/components/enhanced-filters.tsx
+++ b/apps/web-admin/src/app/components/enhanced-filters.tsx
@@ -184,9 +184,9 @@ function EnhancedFilters() {
             onChange={(e) => setFilterByActive(e.target.value)}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
           >
-            <option value="all">📊 Todos los estados</option>
-            <option value="active">✅ Solo activos</option>
-            <option value="inactive">❌ Solo inactivos</option>
+            <option value="all">📊 All statuses</option>
+            <option value="active">✅ Active only</option>
+            <option value="inactive">❌ Inactive only</option>
           </select>
         </div>
 
@@ -197,11 +197,11 @@ function EnhancedFilters() {
             onChange={(e) => setActivityFilter(e.target.value)}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
           >
-            <option value="all">🎵 Toda la actividad</option>
-            <option value="recent">🔥 Activos recientes (7d)</option>
-            <option value="inactive_30d">😴 Inactivos 30+ días</option>
-            <option value="no_scrobbles">🚫 Sin scrobbles</option>
-            <option value="high_activity">⭐ Alta actividad (100+)</option>
+            <option value="all">🎵 All activity</option>
+            <option value="recent">🔥 Recent active (7d)</option>
+            <option value="inactive_30d">😴 Inactive 30+ days</option>
+            <option value="no_scrobbles">🚫 No scrobbles</option>
+            <option value="high_activity">⭐ High activity (100+)</option>
           </select>
         </div>
       </div>
@@ -214,85 +214,85 @@ function EnhancedFilters() {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
             {/* Subscription Filter */}
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">💳 Suscripción</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">💳 Subscription</label>
               <select
                 value={subscriptionFilter}
                 onChange={(e) => setSubscriptionFilter(e.target.value)}
                 className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
-                <option value="all">Todas</option>
+                <option value="all">All</option>
                 <option value="free">🆓 Free</option>
                 <option value="pro">⭐ Pro</option>
-                <option value="active_subscription">✅ Suscripción activa</option>
-                <option value="canceled">❌ Cancelada</option>
+                <option value="active_subscription">✅ Active subscription</option>
+                <option value="canceled">❌ Canceled</option>
                 <option value="trial">🎯 Trial</option>
               </select>
             </div>
 
             {/* Setup Completion Filter */}
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">⚙️ Configuración</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">⚙️ Setup</label>
               <select
                 value={setupFilter}
                 onChange={(e) => setSetupFilter(e.target.value)}
                 className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
-                <option value="all">Todas</option>
-                <option value="complete">✅ Completa</option>
-                <option value="incomplete">⚠️ Incompleta</option>
-                <option value="no_cookie">🍪 Sin cookie YTMusic</option>
-                <option value="no_lastfm">🎵 Sin Last.fm</option>
+                <option value="all">All</option>
+                <option value="complete">✅ Complete</option>
+                <option value="incomplete">⚠️ Incomplete</option>
+                <option value="no_cookie">🍪 No YTMusic cookie</option>
+                <option value="no_lastfm">🎵 No Last.fm</option>
               </select>
             </div>
 
             {/* Health Status Filter */}
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">🏥 Estado de salud</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">🏥 Health status</label>
               <select
                 value={healthFilter}
                 onChange={(e) => setHealthFilter(e.target.value)}
                 className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
-                <option value="all">Todos</option>
-                <option value="healthy">💚 Saludable</option>
-                <option value="warnings">⚠️ Con advertencias</option>
-                <option value="errors">❌ Con errores</option>
-                <option value="auth_failures">🔐 Fallos de auth</option>
-                <option value="network_failures">🌐 Fallos de red</option>
+                <option value="all">All</option>
+                <option value="healthy">💚 Healthy</option>
+                <option value="warnings">⚠️ With warnings</option>
+                <option value="errors">❌ With errors</option>
+                <option value="auth_failures">🔐 Auth failures</option>
+                <option value="network_failures">🌐 Network failures</option>
               </select>
             </div>
 
             {/* Registration Date Filter */}
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">📅 Registrado</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">📅 Registered</label>
               <select
                 value={dateRangeFilter}
                 onChange={(e) => setDateRangeFilter(e.target.value)}
                 className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
-                <option value="all">Cualquier fecha</option>
-                <option value="today">🔥 Hoy</option>
-                <option value="week">📅 Esta semana</option>
-                <option value="month">📅 Este mes</option>
-                <option value="quarter">📅 Últimos 3 meses</option>
-                <option value="year">📅 Este año</option>
-                <option value="older">📅 Más de 1 año</option>
+                <option value="all">Any date</option>
+                <option value="today">🔥 Today</option>
+                <option value="week">📅 This week</option>
+                <option value="month">📅 This month</option>
+                <option value="quarter">📅 Last 3 months</option>
+                <option value="year">📅 This year</option>
+                <option value="older">📅 More than 1 year</option>
               </select>
             </div>
 
             {/* Notifications Filter */}
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">🔔 Notificaciones</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">🔔 Notifications</label>
               <select
                 value={notificationsFilter}
                 onChange={(e) => setNotificationsFilter(e.target.value)}
                 className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
-                <option value="all">Todas</option>
-                <option value="enabled">🔔 Habilitadas</option>
-                <option value="disabled">🔕 Deshabilitadas</option>
-                <option value="high_notifications">⚠️ Muchas notificaciones</option>
-                <option value="recent_notifications">📧 Notificados recientemente</option>
+                <option value="all">All</option>
+                <option value="enabled">🔔 Enabled</option>
+                <option value="disabled">🔕 Disabled</option>
+                <option value="high_notifications">⚠️ Many notifications</option>
+                <option value="recent_notifications">📧 Recently notified</option>
               </select>
             </div>
           </div>

--- a/apps/web-admin/src/app/components/enhanced-filters.tsx
+++ b/apps/web-admin/src/app/components/enhanced-filters.tsx
@@ -198,7 +198,7 @@ function EnhancedFilters() {
             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
           >
             <option value="all">🎵 All activity</option>
-            <option value="recent">🔥 Recent active (7d)</option>
+            <option value="recent">🔥 Recently active (7d)</option>
             <option value="inactive_30d">😴 Inactive 30+ days</option>
             <option value="no_scrobbles">🚫 No scrobbles</option>
             <option value="high_activity">⭐ High activity (100+)</option>

--- a/apps/web-admin/src/app/components/enhanced-stats.tsx
+++ b/apps/web-admin/src/app/components/enhanced-stats.tsx
@@ -131,7 +131,7 @@ export default function EnhancedStats() {
           <div className="bg-purple-50 border border-purple-200 rounded-lg p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Active 24h</p>
+                <p className="text-sm font-medium text-gray-600">Active Users (24h)</p>
                 <p className="text-2xl font-bold text-purple-600">{stats.usersWithRecentScrobbles24h.toLocaleString()}</p>
                 <p className="text-xs text-gray-500 mt-1">{stats.recentActivityRate24h}% of total</p>
               </div>

--- a/apps/web-admin/src/app/components/enhanced-stats.tsx
+++ b/apps/web-admin/src/app/components/enhanced-stats.tsx
@@ -94,17 +94,17 @@ export default function EnhancedStats() {
   };
 
   const getGrowthIndicator = (value: number) => {
-    if (value > 10) return '📈 Excelente';
-    if (value > 5) return '📊 Bueno';
-    if (value > 0) return '🔄 Lento';
-    return '😴 Sin crecimiento';
+    if (value > 10) return '📈 Excellent';
+    if (value > 5) return '📊 Good';
+    if (value > 0) return '🔄 Slow';
+    return '😴 No growth';
   };
 
   return (
     <div className="space-y-6">
       {/* Overview Cards */}
       <div>
-        <h3 className="text-lg font-semibold text-gray-800 mb-4">📊 Resumen General</h3>
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">📊 General Overview</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <div className="bg-blue-50 border border-blue-200 rounded-lg p-6">
             <div className="flex items-center justify-between">
@@ -131,9 +131,9 @@ export default function EnhancedStats() {
           <div className="bg-purple-50 border border-purple-200 rounded-lg p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Activos 24h</p>
+                <p className="text-sm font-medium text-gray-600">Active 24h</p>
                 <p className="text-2xl font-bold text-purple-600">{stats.usersWithRecentScrobbles24h.toLocaleString()}</p>
-                <p className="text-xs text-gray-500 mt-1">{stats.recentActivityRate24h}% del total</p>
+                <p className="text-xs text-gray-500 mt-1">{stats.recentActivityRate24h}% of total</p>
               </div>
               <div className="text-2xl">🔥</div>
             </div>
@@ -154,14 +154,14 @@ export default function EnhancedStats() {
 
       {/* Activity Cards */}
       <div>
-        <h3 className="text-lg font-semibold text-gray-800 mb-4">⚡ Actividad Reciente</h3>
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">⚡ Recent Activity</h3>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Scrobbles Hoy</p>
+                <p className="text-sm font-medium text-gray-600">Scrobbles Today</p>
                 <p className="text-2xl font-bold text-emerald-600">{stats.recentScrobbles24h.toLocaleString()}</p>
-                <p className="text-xs text-gray-500 mt-1">Últimas 24 horas</p>
+                <p className="text-xs text-gray-500 mt-1">Last 24 hours</p>
               </div>
               <div className="text-2xl">📈</div>
             </div>
@@ -183,7 +183,7 @@ export default function EnhancedStats() {
               <div>
                 <p className="text-sm font-medium text-gray-600">Scrobbles 30d</p>
                 <p className="text-2xl font-bold text-cyan-600">{stats.recentScrobbles30d.toLocaleString()}</p>
-                <p className="text-xs text-gray-500 mt-1">Último mes</p>
+                <p className="text-xs text-gray-500 mt-1">Last month</p>
               </div>
               <div className="text-2xl">📋</div>
             </div>
@@ -193,14 +193,14 @@ export default function EnhancedStats() {
 
       {/* Health Metrics */}
       <div>
-        <h3 className="text-lg font-semibold text-gray-800 mb-4">🩺 Estado del Sistema</h3>
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">🩺 System Health</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <div className={`border rounded-lg p-6 ${getHealthColor(stats.usersWithAuthFailures, stats.totalUsers)}`}>
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Fallos de Auth</p>
+                <p className="text-sm font-medium text-gray-600">Auth Failures</p>
                 <p className="text-2xl font-bold">{stats.usersWithAuthFailures.toLocaleString()}</p>
-                <p className="text-xs text-gray-500 mt-1">Credenciales expiradas</p>
+                <p className="text-xs text-gray-500 mt-1">Expired credentials</p>
               </div>
               <div className="text-2xl">🔐</div>
             </div>
@@ -209,9 +209,9 @@ export default function EnhancedStats() {
           <div className={`border rounded-lg p-6 ${getHealthColor(stats.usersWithNetworkFailures, stats.totalUsers)}`}>
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Fallos de Red</p>
+                <p className="text-sm font-medium text-gray-600">Network Failures</p>
                 <p className="text-2xl font-bold">{stats.usersWithNetworkFailures.toLocaleString()}</p>
-                <p className="text-xs text-gray-500 mt-1">Problemas temporales</p>
+                <p className="text-xs text-gray-500 mt-1">Temporary issues</p>
               </div>
               <div className="text-2xl">🌐</div>
             </div>
@@ -220,9 +220,9 @@ export default function EnhancedStats() {
           <div className={`border rounded-lg p-6 ${getHealthColor(stats.usersWithoutCookie, stats.totalUsers)}`}>
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Sin Cookie YTM</p>
+                <p className="text-sm font-medium text-gray-600">No YTM Cookie</p>
                 <p className="text-2xl font-bold">{stats.usersWithoutCookie.toLocaleString()}</p>
-                <p className="text-xs text-gray-500 mt-1">Setup incompleto</p>
+                <p className="text-xs text-gray-500 mt-1">Incomplete setup</p>
               </div>
               <div className="text-2xl">🍪</div>
             </div>
@@ -231,9 +231,9 @@ export default function EnhancedStats() {
           <div className={`border rounded-lg p-6 ${getHealthColor(stats.usersWithoutLastFm, stats.totalUsers)}`}>
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Sin Last.fm</p>
+                <p className="text-sm font-medium text-gray-600">No Last.fm</p>
                 <p className="text-2xl font-bold">{stats.usersWithoutLastFm.toLocaleString()}</p>
-                <p className="text-xs text-gray-500 mt-1">Setup incompleto</p>
+                <p className="text-xs text-gray-500 mt-1">Incomplete setup</p>
               </div>
               <div className="text-2xl">🎧</div>
             </div>
@@ -270,7 +270,7 @@ export default function EnhancedStats() {
 
         {/* Top Artists */}
         <div>
-          <h3 className="text-lg font-semibold text-gray-800 mb-4">🎤 Top Artistas (30d)</h3>
+          <h3 className="text-lg font-semibold text-gray-800 mb-4">🎤 Top Artists (30d)</h3>
           <div className="bg-white border rounded-lg p-6">
             <div className="space-y-3">
               {stats.topArtists.slice(0, 5).map((artist, index) => (
@@ -285,7 +285,7 @@ export default function EnhancedStats() {
                 </div>
               ))}
               {stats.topArtists.length === 0 && (
-                <p className="text-sm text-gray-500 text-center py-4">No hay datos suficientes</p>
+                <p className="text-sm text-gray-500 text-center py-4">Not enough data</p>
               )}
             </div>
           </div>
@@ -295,7 +295,7 @@ export default function EnhancedStats() {
       {/* Failure Breakdown */}
       {Object.keys(stats.failureStats).length > 0 && (
         <div>
-          <h3 className="text-lg font-semibold text-gray-800 mb-4">⚠️ Tipos de Fallos</h3>
+          <h3 className="text-lg font-semibold text-gray-800 mb-4">⚠️ Failure Types</h3>
           <div className="bg-white border rounded-lg p-6">
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
               {Object.entries(stats.failureStats).map(([type, count]) => (

--- a/apps/web-admin/src/app/components/enhanced-users-table.tsx
+++ b/apps/web-admin/src/app/components/enhanced-users-table.tsx
@@ -67,7 +67,7 @@ export default function EnhancedUsersTable({
     if (!hasSetup) {
       return (
         <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
-          🔧 Setup Incompleto
+          🔧 Incomplete Setup
         </span>
       );
     }
@@ -75,7 +75,7 @@ export default function EnhancedUsersTable({
     if (!user.isActive) {
       return (
         <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
-          ⏸️ Pausado
+          ⏸️ Paused
         </span>
       );
     }
@@ -91,14 +91,14 @@ export default function EnhancedUsersTable({
               : "❌";
       return (
         <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
-          {failureEmoji} {user.consecutiveFailures} fallos
+          {failureEmoji} {user.consecutiveFailures} failures
         </span>
       );
     }
 
     return (
       <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
-        ✅ Activo
+        ✅ Active
       </span>
     );
   };
@@ -113,17 +113,17 @@ export default function EnhancedUsersTable({
       : null;
 
     if (!user.lastSuccessfulScrobble) {
-      return <span className="text-gray-400">🔘 Nunca</span>;
+      return <span className="text-gray-400">🔘 Never</span>;
     }
 
     if (daysSinceLastScrobble! <= 1) {
-      return <span className="text-green-600">🟢 Muy activo</span>;
+      return <span className="text-green-600">🟢 Very active</span>;
     } else if (daysSinceLastScrobble! <= 7) {
-      return <span className="text-yellow-600">🟡 Activo</span>;
+      return <span className="text-yellow-600">🟡 Active</span>;
     } else if (daysSinceLastScrobble! <= 30) {
-      return <span className="text-orange-600">🟠 Inactivo</span>;
+      return <span className="text-orange-600">🟠 Inactive</span>;
     } else {
-      return <span className="text-red-600">🔴 Muy inactivo</span>;
+      return <span className="text-red-600">🔴 Very inactive</span>;
     }
   };
 
@@ -139,7 +139,7 @@ export default function EnhancedUsersTable({
     if (days > 0) return `${days}d`;
     if (hours > 0) return `${hours}h`;
     if (minutes > 0) return `${minutes}m`;
-    return "Ahora";
+    return "Now";
   };
 
   const getSetupProgress = (user: User) => {
@@ -189,7 +189,7 @@ export default function EnhancedUsersTable({
                 Setup
               </th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Actividad
+                Activity
               </th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                 Scrobbles
@@ -198,10 +198,10 @@ export default function EnhancedUsersTable({
                 Plan
               </th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Fallos
+                Failures
               </th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Acciones
+                Actions
               </th>
             </tr>
           </thead>
@@ -272,15 +272,15 @@ export default function EnhancedUsersTable({
                 <td className="px-4 py-4 whitespace-nowrap">
                   <div className="text-sm space-y-1">
                     <div>
-                      <span className="text-gray-500">Último:</span>{" "}
+                      <span className="text-gray-500">Last:</span>{" "}
                       <span className="font-medium">
                         {user.lastSuccessfulScrobble
                           ? formatTimeAgo(user.lastSuccessfulScrobble)
-                          : "Nunca"}
+                          : "Never"}
                       </span>
                     </div>
                     <div className="text-xs text-gray-500">
-                      Registrado: {formatTimeAgo(user.createdAt)}
+                      Registered: {formatTimeAgo(user.createdAt)}
                     </div>
                   </div>
                 </td>
@@ -293,7 +293,7 @@ export default function EnhancedUsersTable({
                     </div>
                     <div className="text-xs text-gray-500">
                       {user.Songs.length > 0 && (
-                        <>Último: {formatTimeAgo(user.Songs[0].addedAt)}</>
+                        <>Last: {formatTimeAgo(user.Songs[0].addedAt)}</>
                       )}
                     </div>
                   </div>
@@ -325,7 +325,7 @@ export default function EnhancedUsersTable({
                     {user.consecutiveFailures > 0 ? (
                       <div className="space-y-1">
                         <div className="font-semibold text-red-600">
-                          {user.consecutiveFailures} consecutivos
+                          {user.consecutiveFailures} consecutive
                         </div>
                         <div className="text-xs text-gray-500">
                           {user.lastFailureType} •{" "}
@@ -333,13 +333,13 @@ export default function EnhancedUsersTable({
                         </div>
                         {user.authNotificationCount > 0 && (
                           <div className="text-xs text-orange-600">
-                            📧 {user.authNotificationCount} notificaciones
+                            📧 {user.authNotificationCount} notifications
                           </div>
                         )}
                       </div>
                     ) : (
                       <span className="text-green-600 text-sm">
-                        ✅ Sin fallos
+                        ✅ No failures
                       </span>
                     )}
                   </div>
@@ -358,14 +358,14 @@ export default function EnhancedUsersTable({
                           : "bg-green-100 text-green-700 hover:bg-green-200"
                       }`}
                     >
-                      {user.isActive ? "⏸️ Pausar" : "▶️ Activar"}
+                      {user.isActive ? "⏸️ Pause" : "▶️ Activate"}
                     </button>
 
                     {user.consecutiveFailures > 0 && (
                       <button
                         onClick={() => handleResetFailures(user.id)}
                         className="px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700 hover:bg-blue-200 transition-colors"
-                        title="Resetear fallos consecutivos"
+                        title="Reset consecutive failures"
                       >
                         🔄 Reset
                       </button>
@@ -394,15 +394,15 @@ export default function EnhancedUsersTable({
           <div className="flex items-center space-x-4 text-xs">
             <div className="flex items-center space-x-1">
               <span className="w-2 h-2 bg-green-500 rounded-full"></span>
-              <span>Saludable</span>
+              <span>Healthy</span>
             </div>
             <div className="flex items-center space-x-1">
               <span className="w-2 h-2 bg-yellow-500 rounded-full"></span>
-              <span>Atención</span>
+              <span>Warning</span>
             </div>
             <div className="flex items-center space-x-1">
               <span className="w-2 h-2 bg-red-500 rounded-full"></span>
-              <span>Crítico</span>
+              <span>Critical</span>
             </div>
           </div>
         </div>

--- a/apps/web-admin/src/app/components/enhanced-users-table.tsx
+++ b/apps/web-admin/src/app/components/enhanced-users-table.tsx
@@ -325,7 +325,7 @@ export default function EnhancedUsersTable({
                     {user.consecutiveFailures > 0 ? (
                       <div className="space-y-1">
                         <div className="font-semibold text-red-600">
-                          {user.consecutiveFailures} consecutive
+                          {user.consecutiveFailures} consecutive failures
                         </div>
                         <div className="text-xs text-gray-500">
                           {user.lastFailureType} •{" "}


### PR DESCRIPTION
Fixes #39

This PR translates all Spanish text in the admin interface to English, making it more accessible to international users.

## Changes
- Updated all filter labels and options in enhanced-filters.tsx
- Translated status indicators, table headers, and action buttons in enhanced-users-table.tsx
- Converted statistical section headers and labels in enhanced-stats.tsx
- Maintained all emoji icons and styling for consistent UX

🤖 Generated with [Claude Code](https://claude.ai/code)